### PR TITLE
Check if member exists before emitting it

### DIFF
--- a/lib/IrcCommands/PartCommand.js
+++ b/lib/IrcCommands/PartCommand.js
@@ -25,7 +25,8 @@ class PartCommand extends JoinCommand {
 		 * @event BanchoClient#PART
 		 * @type {BanchoChannelMember}
 		 */
-		client.emit("PART", channel.channelMembers.get(user.ircUsername));
+		if(channel.channelMembers.has(user.ircUsername))
+			client.emit("PART", channel.channelMembers.get(user.ircUsername));
 		if(user.isClient()) {
 			channel.joined = false;
 			channel.channelMembers.clear();


### PR DESCRIPTION
### Reproducing the error
```js
const channel = await client.createLobby(`LobbyName`);
await channel.leave();
```
### The reason this error exists
IRC sends duplicate PART events causes the library to crash
```
:Khoo_Hao_Yit!cho@ppy.sh PART :#mp_91173059
:Khoo_Hao_Yit!cho@ppy.sh PART :#mp_91173059
```
### Pull request goal
This pull request aims to fix this issue by checking if the member exists before emitting it