### PR TITLE
Handle cases where getPlayerSlot() returns undefined

### DIFF
--- a/lib/Multiplayer/BanchoLobby.js
+++ b/lib/Multiplayer/BanchoLobby.js
@@ -221,7 +221,9 @@ class BanchoLobby extends EventEmitter {
 							 */
 							const oldSlot = this.getPlayerSlot(player);
 							this.slots[ret.slot - 1] = player;
-							this.slots[oldSlot] = null;
+							if(oldSlot) {
+								this.slots[oldSlot] = null;
+							}
 							this.emit("playerMoved", {
 								player: player,
 								slot: (ret.slot - 1)
@@ -239,7 +241,9 @@ class BanchoLobby extends EventEmitter {
 							 * @type {BanchoLobbyPlayer}
 							 */
 							const slot = this.getPlayerSlot(player);
-							this.slots[slot] = null;
+							if(slot) {
+								this.slots[slot] = null;
+							}
 							this.emit("playerLeft", player);
 							if(player.isHost) {
 								this.emit("hostCleared");


### PR DESCRIPTION
When bancho.js joins an existing lobby, you can receive playerMoved or
playerLeft events *before* bancho.js had the time to fetch the lobby
info. When that happens, an unhandled error is thrown, since "undefined"
is not a valid key for the slots array.

I chose to just check if getPlayerSlot() returns something, but a better
fix might be to ignore those events until the lobby is initialized.

Original errors (as logged by sentry):

```
TypeError: Cannot add property undefined, object is not extensible
  File "/root/osubot/node_modules/bancho.js/lib/Multiplayer/BanchoLobby.js", line 224, col 28, in null.<anonymous>
    this.slots[oldSlot] = null;
  File "node:internal/process/task_queues", line 96, col 5, in processTicksAndRejections
```

```
TypeError: Cannot add property undefined, object is not extensible
  File "/root/osubot/node_modules/bancho.js/lib/Multiplayer/BanchoLobby.js", line 242, col 25, in null.<anonymous>
    this.slots[slot] = null;
  File "node:internal/process/task_queues", line 96, col 5, in processTicksAndRejections
```