### PR TITLE
BanchoLobby cdelaration should extend EventEmitter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -331,7 +331,7 @@ declare module "bancho.js" {
 	 * 
  	 * Highly recommended to await updateSettings before manipulating (else some properties will be null).
 	 */
-	class BanchoLobby {
+	class BanchoLobby extends EventEmitter {
 		channel: BanchoMultiplayerChannel
 		/**
 		 * Multiplayer lobby ID (used in multiplayer history links)


### PR DESCRIPTION
The implementation of BanchoLobby extends EventEmitter, but the type declaration was missing this. With this change, EventEmitter properties can be accessed, such as `off` for removing events.